### PR TITLE
update node from 12 to 16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ inputs:
     required: false
 
 runs:
-  using: node12
+  using: node16
   main: dist/main/index.js
   post: dist/post/index.js
 


### PR DESCRIPTION
The following actions uses node12 which is deprecated and will be forced to run on node16: NiceLabs/rclone-action@master. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/